### PR TITLE
Add :info as an alternative to :execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The first argument is the command in which the trigger will be tied. It could be
 * ```:append_to_path => ["dir", "dir"]```: additional places where looking for the script. See [this wiki page](https://github.com/emyl/vagrant-triggers/wiki/The-:append_to_path-option) for details.
 * ```:force => true```: continue even if the script fails (exits with non-zero code)
 * ```:stdout => true```: display script output
+* ```:info => "string"```: optional: an informational message to be displayed, instead of executing a command. This is only displayed if :execute is not set..
 
 ### Skipping execution
 

--- a/lib/vagrant-triggers/action/trigger.rb
+++ b/lib/vagrant-triggers/action/trigger.rb
@@ -65,6 +65,8 @@ module VagrantPlugins
               @options = trigger[:options]
               if @options[:execute]
                 execute(@options[:execute])
+              elsif @options[:info]
+                @env[:ui].info @options[:info]
               else
                 @logger.debug("Trigger command not found.")
               end


### PR DESCRIPTION
Instead of executing a command, it uses Vagrant's UI object to print an
informational message. This is useful if you want to show messages
during certain Vagrant commands, but not others, but don't have any need
to execute a script.
