### PR TITLE
Fix Vagrant 1.9+ compatibility.

### DIFF
--- a/lib/vagrant-triggers/dsl.rb
+++ b/lib/vagrant-triggers/dsl.rb
@@ -1,4 +1,3 @@
-require "bundler"
 require "log4r"
 require "vagrant/util/subprocess"
 
@@ -46,7 +45,7 @@ module VagrantPlugins
         env_backup = ENV.to_hash
         begin
           result = nil
-          Bundler.with_clean_env do
+          Vagrant::Util::Env.with_clean_env do
             build_environment
             @buffer.clear
             Dir.chdir(@machine.env.root_path) do

--- a/vagrant-triggers.gemspec
+++ b/vagrant-triggers.gemspec
@@ -48,8 +48,6 @@ Gem::Specification.new do |spec|
   spec.test_files   = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_path = "lib"
 
-  spec.add_dependency "bundler", "~> 1.3"
-
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 end


### PR DESCRIPTION
Vagrant 1.9+ is not using Bundler for management of its dependencies, so
drop the Bundler dependency.

This might compatible with Vagrant 1.7.2+. On the other hand, the missing dependency might be problem for Vagrant < 1.9